### PR TITLE
Specify ASPNETCORE_ENVIRONMENT in docker-compose.yaml.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
     ports:
       - "5003:5003"
     environment:
+      ASPNETCORE_ENVIRONMENT: Development
       AWS_DEFAULT_REGION: us-east-2
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
The clients-api microservice is not able to find the correct DynamoDB table when running locally on docker because it is not reading the `appsettings.Development.json` file where the table name prefix is specified.

This patch fixes the problem by specifying the appropriate environment variable in `docker-compose.yaml`.