### PR TITLE
Fix code to work in any region.

### DIFF
--- a/clients-api/src/Services/ClientService.cs
+++ b/clients-api/src/Services/ClientService.cs
@@ -24,7 +24,7 @@ namespace ACG.EKS.Bookstore.Clients_API.Services
 
         public ClientService(IDynamoDBSettings settings) 
         {
-            _dynamoDBClient = new AmazonDynamoDBClient(RegionEndpoint.USEast2);
+            _dynamoDBClient = new AmazonDynamoDBClient();
             var config = new DynamoDBContextConfig { TableNamePrefix = settings.Prefix };
             _context = new DynamoDBContext(_dynamoDBClient, config);
         }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
     environment:
       DYNAMODB_TABLE: development-inventory
       RESOURCE_API_ENDPOINT: http://resources-api:5000
-      AWS_DEFAULT_REGION: us-east-2
+      AWS_REGION: us-east-2
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
 
@@ -29,7 +29,7 @@ services:
     ports:
       - "5003:5003"
     environment:
-      AWS_DEFAULT_REGION: us-east-2
+      AWS_REGION: us-east-2
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
 
@@ -38,7 +38,7 @@ services:
     ports:
       - "5004:3000"
     environment:
-      AWS_DEFAULT_REGION: us-east-2
+      AWS_REGION: us-east-2
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
       DYNAMODB_TABLE: development-renting


### PR DESCRIPTION
Remove hardcoded region in clients-api.
Update `docker-compose.yaml` to specify region correctly.

Note that all AWS SDKs use the `AWS_REGION` environment varible *except* boto3 which uses `AWS_DEFAULT_REGION`.