### PR TITLE
Disable AWS X-Ray in resource-api until it's needed.

### DIFF
--- a/resource-api/infra/helm-v2/templates/deployment.yaml
+++ b/resource-api/infra/helm-v2/templates/deployment.yaml
@@ -33,7 +33,9 @@ spec:
             - name: DYNAMODB_TABLE 
               value: {{ .Release.Namespace }}-resources
             - name: AWS_DEFAULT_REGION
-              value: {{ .Values.aws.region}}
+              value: {{ .Values.aws.region }}
+            - name: AWS_XRAY_SDK_ENABLED
+              value: "{{ .Values.aws.xray_enabled }}"
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/resource-api/infra/helm-v2/values.yaml
+++ b/resource-api/infra/helm-v2/values.yaml
@@ -16,6 +16,7 @@ service:
 
 aws:
   region: us-east-2
+  xray_enabled: "false"
 
 resources: {}
   # limits:

--- a/resource-api/infra/helm-v3/templates/deployment.yaml
+++ b/resource-api/infra/helm-v3/templates/deployment.yaml
@@ -33,7 +33,9 @@ spec:
             - name: DYNAMODB_TABLE 
               value: {{ .Release.Namespace }}-resources
             - name: AWS_DEFAULT_REGION
-              value: {{ .Values.aws.region}}
+              value: {{ .Values.aws.region }}
+            - name: AWS_XRAY_SDK_ENABLED
+              value: "{{ .Values.aws.xray_enabled }}"
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/resource-api/infra/helm-v3/values.development.yaml
+++ b/resource-api/infra/helm-v3/values.development.yaml
@@ -1,3 +1,6 @@
 image:
   repository: 750796802028.dkr.ecr.us-east-2.amazonaws.com/bookstore.resources-api
   tag: latest
+
+aws:
+  xray_enabled: "true"

--- a/resource-api/infra/helm-v3/values.prod.yaml
+++ b/resource-api/infra/helm-v3/values.prod.yaml
@@ -1,3 +1,6 @@
 image:
   repository: 750796802028.dkr.ecr.us-east-2.amazonaws.com/bookstore.resources-api
   tag: latest
+
+aws:
+  xray_enabled: "false"

--- a/resource-api/infra/helm/templates/deployment.yaml
+++ b/resource-api/infra/helm/templates/deployment.yaml
@@ -32,7 +32,9 @@ spec:
             - name: DYNAMODB_TABLE 
               value: {{ .Release.Namespace }}-resources
             - name: AWS_DEFAULT_REGION
-              value: {{ .Values.aws.region}}
+              value: {{ .Values.aws.region }}
+            - name: AWS_XRAY_SDK_ENABLED
+              value: "{{ .Values.aws.xray_enabled }}"
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/resource-api/infra/helm/values.yaml
+++ b/resource-api/infra/helm/values.yaml
@@ -16,6 +16,7 @@ service:
 
 aws:
   region: us-east-2
+  xray_enabled: "false"
 
 resources: {}
   # limits:


### PR DESCRIPTION
The resource-api microservice would immediately error out and stop working for me when it was unable to contact the x-ray daemon. I don't remember if this was a problem when I was using the image from your Docker Hub, but it definitely wasn't working when I started building my own images on CodeBuild.

This patch adds a configurable `AWS_XRAY_SDK_ENABLED` variable to the helm template and keeps it disabled until we're ready for it with the v3 deployment in the AppMesh chapter.