### PR TITLE
Changing Instance Type from t2 to t3

### DIFF
--- a/Infrastructure/eksctl/01-initial-cluster/cluster.yaml
+++ b/Infrastructure/eksctl/01-initial-cluster/cluster.yaml
@@ -11,6 +11,6 @@ vpc:
 
 nodeGroups:
   - name: eks-node-group
-    instanceType: t2.micro
+    instanceType: t3.micro
     desiredCapacity: 3
     privateNetworking: true

--- a/Infrastructure/eksctl/02-increasing-size/cluster.yaml
+++ b/Infrastructure/eksctl/02-increasing-size/cluster.yaml
@@ -11,6 +11,6 @@ vpc:
 
 nodeGroups:
   - name: eks-node-group-v2
-    instanceType: t2.medium
+    instanceType: t3.medium
     desiredCapacity: 3
     privateNetworking: true

--- a/Infrastructure/eksctl/04-managed-nodes/cluster.yaml
+++ b/Infrastructure/eksctl/04-managed-nodes/cluster.yaml
@@ -11,6 +11,6 @@ vpc:
 
 managedNodeGroups:
   - name: eks-node-group-managed-nodes
-    instanceType: t2.medium
+    instanceType: t3.medium
     desiredCapacity: 3
     privateNetworking: true


### PR DESCRIPTION
Based on this issue: https://github.com/ACloudGuru-Resources/Course_Practical_Guide_EKS/issues/27

Since *"t2"* is not present in some regions on AWS, we have changed the default instance type on the EKSCTL config files to *"t3"*.

Thanks to [songmic-ai](https://github.com/songmic-ai) for updating on this!