### PR TITLE
Update Dockerfile

### DIFF
--- a/front-end/Dockerfile
+++ b/front-end/Dockerfile
@@ -1,7 +1,20 @@
+# FROM node:carbon-alpine
+# WORKDIR /opt/forms
+# COPY package*.json ./
+# RUN npm install
+# COPY . ./
+# RUN npm run build
+
+# FROM nginx:1.15-alpine
+# COPY --from=0 /opt/forms/dist /usr/share/nginx/html
+# COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 FROM node:carbon-alpine
 WORKDIR /opt/forms
 COPY package*.json ./
-RUN npm install
+RUN apk add --no-cache --virtual .gyp python make g++ \
+   && npm install \
+   && apk del .gyp
 COPY . ./
 RUN npm run build
 


### PR DESCRIPTION
fixed dockerfile to run front-end since it was having errors building it

below the following error running docker-compose up
 > [front-end stage-0 4/6] RUN npm install:
53.86 
53.86 > node-sass@4.10.0 install /opt/forms/node_modules/@angular-devkit/build-angular/node_modules/node-sass
53.86 > node scripts/install.js
53.86 
54.04 Downloading binary from https://github.com/sass/node-sass/releases/download/v4.10.0/linux-arm64-57_binding.node
56.92 Cannot download "https://github.com/sass/node-sass/releases/download/v4.10.0/linux-arm64-57_binding.node": 
56.92 
56.92 HTTP error 404 Not Found
56.92 
56.92 Hint: If github.com is not accessible in your location
56.92       try setting a proxy via HTTP_PROXY, e.g. 
56.92 
56.92       export HTTP_PROXY=http://example.com:1234
56.92 
56.92 or configure npm proxy via
56.92 
56.92       npm config set proxy http://example.com:8080
56.94 